### PR TITLE
Use only associations to generate foreign keys

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,16 @@
+{
+  "development": {
+    "dialect": "sqlite",
+    "storage": "./dev.sqlite"
+  },
+  "test": {
+    "dialect": "sqlite",
+    "storage": ":memory:"
+  },
+  "staging": {
+    "database": "wcb",
+    "host": "localhost",
+    "dialect": "mysql",
+    "port": 3306
+  }
+}

--- a/lib/models/donors.js
+++ b/lib/models/donors.js
@@ -5,22 +5,6 @@ module.exports = function (sequelize, DataTypes) {
       allowNull: false,
       primaryKey: true,
       autoIncrement: true
-    },
-    donor: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'donor',
-        key: 'id'
-      }
-    },
-    participant: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'participant',
-        key: 'id'
-      }
     }
   }, {
     tableName: 'donors'

--- a/lib/models/event.js
+++ b/lib/models/event.js
@@ -22,14 +22,6 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.DATE,
       allowNull: false
     },
-    locality: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'locality',
-        key: 'id'
-      }
-    },
     team_limit: {
       type: DataTypes.INTEGER,
       allowNull: false
@@ -41,14 +33,6 @@ module.exports = function (sequelize, DataTypes) {
     team_building_end: {
       type: DataTypes.DATE,
       allowNull: false
-    },
-    cause: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'cause',
-        key: 'id'
-      }
     }
   }, {
     tableName: 'event'

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,10 +1,11 @@
 const fs = require('fs')
 const path = require('path')
 const Sequelize = require('sequelize')
-if (!process.env.NODE_ENV) { throw new Error('NODE_ENV is not set!') }
-const dbSetting = require(path.resolve(`./settings/${process.env.NODE_ENV}.json`))
-dbSetting.define = {timestamps: false, underscored: true}
-const sequelize = new Sequelize(dbSetting.db, process.env.username, process.env.password, dbSetting)
+const env = process.env.NODE_ENV
+if (!env) { throw new Error('NODE_ENV is not set!') }
+const config = require(path.resolve('./config/config.json'))[env]
+config.define = {timestamps: false, underscored: true}
+const sequelize = new Sequelize(config.database, process.env.username, process.env.password, config)
 let db = {}
 fs
   .readdirSync(__dirname)

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -30,8 +30,36 @@ async function dbHealthCheck () {
 // Associations
 db.team.hasMany(db.participant)
 db.participant.belongsTo(db.team)
+
 db.team.belongsToMany(db.achievement, {through: 'achievements'})
 db.achievement.belongsToMany(db.team, {through: 'achievements'})
+
+db.participant.hasMany(db.record)
+db.record.belongsTo(db.participant)
+
+db.source.hasMany(db.record)
+db.record.belongsTo(db.source)
+
+db.source.hasMany(db.participant)
+db.participant.belongsTo(db.source)
+
+db.cause.hasMany(db.participant)
+db.participant.belongsTo(db.cause)
+
+db.event.hasMany(db.participant)
+db.participant.belongsTo(db.event)
+
+db.locality.hasMany(db.event)
+db.event.belongsTo(db.locality)
+
+db.cause.hasMany(db.event)
+db.event.belongsTo(db.cause)
+
+db.participant.belongsToMany(db.sponsor, {through: 'sponsors'})
+db.sponsor.belongsToMany(db.participant, {through: 'sponsors'})
+
+db.participant.belongsToMany(db.donor, {through: 'donors'})
+db.donor.belongsToMany(db.participant, {through: 'donors'})
 
 sequelize.sync({logging: console.log})
 db.sequelize = sequelize

--- a/lib/models/participant.js
+++ b/lib/models/participant.js
@@ -10,30 +10,6 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.STRING,
       allowNull: false,
       unique: true
-    },
-    event_id: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      references: {
-        model: 'event',
-        key: 'id'
-      }
-    },
-    datasource: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      references: {
-        model: 'source',
-        key: 'id'
-      }
-    },
-    preferred_cause: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-      references: {
-        model: 'cause',
-        key: 'id'
-      }
     }
   }, {
     tableName: 'participant'

--- a/lib/models/record.js
+++ b/lib/models/record.js
@@ -6,14 +6,6 @@ module.exports = function (sequelize, DataTypes) {
       primaryKey: true,
       autoIncrement: true
     },
-    participant: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'participant',
-        key: 'id'
-      }
-    },
     date: {
       type: DataTypes.DATE,
       allowNull: false
@@ -21,14 +13,6 @@ module.exports = function (sequelize, DataTypes) {
     distance: {
       type: DataTypes.INTEGER,
       allowNull: false
-    },
-    source: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'source',
-        key: 'id'
-      }
     }
   }, {
     tableName: 'record'

--- a/lib/models/sponsors.js
+++ b/lib/models/sponsors.js
@@ -5,22 +5,6 @@ module.exports = function (sequelize, DataTypes) {
       allowNull: false,
       primaryKey: true,
       autoIncrement: true
-    },
-    sponsor: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'sponsor',
-        key: 'id'
-      }
-    },
-    participant: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'participant',
-        key: 'id'
-      }
     }
   }, {
     tableName: 'sponsors'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
     "start": "node .",
-    "start-dev": "NODE_ENV=dev nodemon .",
+    "start-dev": "NODE_ENV=development nodemon .",
     "test": "NODE_ENV=test istanbul cover --report lcovonly _mocha --recursive"
   },
   "repository": {
@@ -45,6 +45,7 @@
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.2.0",
     "nodemon": "^1.11.0",
+    "sequelize-cli": "^2.7.0",
     "supertest": "^3.0.0"
   }
 }

--- a/settings/dev.json
+++ b/settings/dev.json
@@ -1,4 +1,0 @@
-{
-  "dialect": "sqlite",
-  "storage": "./dev.sqlite"
-}

--- a/settings/staging.json
+++ b/settings/staging.json
@@ -1,6 +1,0 @@
-{
-  "db": "wcb",
-  "host": "localhost",
-  "dialect": "mysql",
-  "port": 3306
-}

--- a/settings/test.json
+++ b/settings/test.json
@@ -1,4 +1,0 @@
-{
-  "dialect": "sqlite",
-  "storage": ":memory:"
-}

--- a/test/achievement-specs.js
+++ b/test/achievement-specs.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('achievement', () => {
   context('GET /achievement', () => {
     it('should return achievements', async () => {
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      let a2 = await model.db.achievement.create({name: 'Paris', distance: 200})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      let a2 = await models.db.achievement.create({name: 'Paris', distance: 200})
       await koaRequest
         .get('/achievement')
         .expect(200)
@@ -23,9 +23,9 @@ describe('achievement', () => {
         })
     })
     it('should return achievements with teams', async () => {
-      let a1 = await model.db.achievement.create({name: 'a1', distance: 1})
-      let t1 = await model.db.team.create({name: 't1'})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let a1 = await models.db.achievement.create({name: 'a1', distance: 1})
+      let t1 = await models.db.team.create({name: 't1'})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievement')
         .expect(200)
@@ -44,7 +44,7 @@ describe('achievement', () => {
         .expect(204)
     })
     it('should return achievement with id=id', async () => {
-      let achievement = await model.db.achievement.create({name: 'London', distance: 100})
+      let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .get('/achievement/' + achievement.id)
         .expect(200)
@@ -54,9 +54,9 @@ describe('achievement', () => {
         })
     })
     it('should return achievement with id=id with teams', async () => {
-      let a1 = await model.db.achievement.create({name: 'a1', distance: 1})
-      let t1 = await model.db.team.create({name: 't1'})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let a1 = await models.db.achievement.create({name: 'a1', distance: 1})
+      let t1 = await models.db.team.create({name: 't1'})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievement/' + a1.id)
         .expect(200)
@@ -82,7 +82,7 @@ describe('achievement', () => {
         })
     })
     it('should return 409 if achievement name conflict', async () => {
-      let a2 = await model.db.achievement.create({name: 'Paris', distance: 100})
+      let a2 = await models.db.achievement.create({name: 'Paris', distance: 100})
       await koaRequest
         .post('/achievement')
         .send({name: a2.name, distance: a2.distance})
@@ -95,7 +95,7 @@ describe('achievement', () => {
 
   context('PATCH /achievement/:id', () => {
     it('should change achievement name and distance', async () => {
-      let achievement = await model.db.achievement.create({name: 'London', distance: 100})
+      let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .patch('/achievement/' + achievement.id)
         .send({name: 'Paris', distance: 200})
@@ -108,8 +108,8 @@ describe('achievement', () => {
         .expect(400, [0])
     })
     it('should return 400 if achievement name conflict', async () => {
-      let a2 = await model.db.achievement.create({name: 'Paris', distance: 200})
-      let a3 = await model.db.achievement.create({name: 'Amsterdam', distance: 300})
+      let a2 = await models.db.achievement.create({name: 'Paris', distance: 200})
+      let a3 = await models.db.achievement.create({name: 'Amsterdam', distance: 300})
       await koaRequest
         .patch('/achievement/' + a2.id)
         .send({name: a3.name})
@@ -122,7 +122,7 @@ describe('achievement', () => {
 
   context('DELETE /achievement/:id', () => {
     it('should delete achievement with id=id', async () => {
-      let achievement = await model.db.achievement.create({name: 'London', distance: 100})
+      let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .del('/achievement/' + achievement.id)
         .expect(204)

--- a/test/achievements-specs.js
+++ b/test/achievements-specs.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('achievements', () => {
@@ -18,9 +18,9 @@ describe('achievements', () => {
         })
     })
     it('should return achievements for team with id=team', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievements/team/' + t1.id)
         .expect(200)
@@ -41,9 +41,9 @@ describe('achievements', () => {
         })
     })
     it('should return achievements for achievement with id=achievement', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievements/achievement/' + a1.id)
         .expect(200)
@@ -56,8 +56,8 @@ describe('achievements', () => {
 
   context('POST /achievements', () => {
     it('should create achievements with team=team and achievement=achievement', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .post('/achievements')
         .send({team_id: t1.id, achievement_id: a1.id})
@@ -68,9 +68,9 @@ describe('achievements', () => {
         })
     })
     it('should return 409 if achievements\' team and achievement conflict', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      let achievements = await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .post('/achievements')
         .send({team_id: achievements.team_id, achievement_id: achievements.achievement_id})
@@ -83,11 +83,11 @@ describe('achievements', () => {
 
   context('PATCH /achievements/:id', () => {
     it('should change achievements team and achievement', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let t2 = await model.db.team.create({name: 'team2'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      let a2 = await model.db.achievement.create({name: 'Paris', distance: 200})
-      let achievements = await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let t2 = await models.db.team.create({name: 'team2'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      let a2 = await models.db.achievement.create({name: 'Paris', distance: 200})
+      let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .patch('/achievements/' + achievements.id)
         .send({team_id: t2.id, achievement_id: a2.id})
@@ -100,12 +100,12 @@ describe('achievements', () => {
         .expect(400, [0])
     })
     it('should return 400 if achievements\' team and achievement conflict', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let t2 = await model.db.team.create({name: 'team2'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      let a2 = await model.db.achievement.create({name: 'Paris', distance: 200})
-      let achievements1 = await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
-      await model.db.achievements.create({team_id: t2.id, achievement_id: a2.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let t2 = await models.db.team.create({name: 'team2'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      let a2 = await models.db.achievement.create({name: 'Paris', distance: 200})
+      let achievements1 = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      await models.db.achievements.create({team_id: t2.id, achievement_id: a2.id})
       await koaRequest
         .patch('/achievements/' + achievements1.id)
         .send({team_id: t2.id, achievement_id: a2.id})
@@ -118,9 +118,9 @@ describe('achievements', () => {
 
   context('DELETE /achievements/:id', () => {
     it('should delete achievements with id=id', async () => {
-      let t1 = await model.db.team.create({name: 'team1'})
-      let a1 = await model.db.achievement.create({name: 'London', distance: 100})
-      let achievements = await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 'team1'})
+      let a1 = await models.db.achievement.create({name: 'London', distance: 100})
+      let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .del('/achievements/' + achievements.id)
         .expect(204)

--- a/test/causes-specs.js
+++ b/test/causes-specs.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('causes', () => {
   context('GET /causes', () => {
     it('should return causes', async () => {
-      let c1 = await model.db.cause.create({name: 'c1'})
-      let c2 = await model.db.cause.create({name: 'c2'})
+      let c1 = await models.db.cause.create({name: 'c1'})
+      let c2 = await models.db.cause.create({name: 'c2'})
       await koaRequest
         .get('/causes')
         .expect(200)
@@ -29,7 +29,7 @@ describe('causes', () => {
         .expect(204)
     })
     it('should return cause with id=id', async () => {
-      let c1 = await model.db.cause.create({name: 'c1'})
+      let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .get('/causes/' + c1.id)
         .expect(200)
@@ -51,7 +51,7 @@ describe('causes', () => {
         })
     })
     it('should return 409 if cause name conflict', async () => {
-      let c2 = await model.db.cause.create({name: 'c2'})
+      let c2 = await models.db.cause.create({name: 'c2'})
       await koaRequest
         .post('/causes')
         .send({name: c2.name})
@@ -64,7 +64,7 @@ describe('causes', () => {
 
   context('PATCH /causes/:id', () => {
     it('should change cause name', async () => {
-      let c1 = await model.db.cause.create({name: 'c1'})
+      let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .patch('/causes/' + c1.id)
         .send({name: 'c2'})
@@ -77,8 +77,8 @@ describe('causes', () => {
         .expect(400, [0])
     })
     it('should return 400 if cause name conflict', async () => {
-      let c2 = await model.db.cause.create({name: 'c2'})
-      let c3 = await model.db.cause.create({name: 'c3'})
+      let c2 = await models.db.cause.create({name: 'c2'})
+      let c3 = await models.db.cause.create({name: 'c3'})
       await koaRequest
         .patch('/causes/' + c2.id)
         .send({name: c3.name})
@@ -91,7 +91,7 @@ describe('causes', () => {
 
   context('DELETE /causes/:id', () => {
     it('should delete cause with id=id', async () => {
-      let c1 = await model.db.cause.create({name: 'c1'})
+      let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .del('/causes/' + c1.id)
         .expect(204)

--- a/test/db-specs.js
+++ b/test/db-specs.js
@@ -2,18 +2,18 @@
 
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
-const model = require('../lib/models')
+const models = require('../lib/models')
 
 chai.should()
 chai.use(chaiAsPromised)
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('Team model', () => {
   it('should save team', async () => {
-    let team = await model.db.team.create({id: 1, name: 'abc'})
+    let team = await models.db.team.create({id: 1, name: 'abc'})
     team['name'].should.equal('abc')
   })
 })

--- a/test/participants-specs.js
+++ b/test/participants-specs.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('participants', () => {
@@ -15,7 +15,7 @@ describe('participants', () => {
         .expect(204)
     })
     it('should return participant with fbid=fbid', async () => {
-      let participant = await model.db.participant.create({fbid: 'p1'})
+      let participant = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .get('/participants/' + participant.fbid)
         .expect(200)
@@ -24,10 +24,10 @@ describe('participants', () => {
         })
     })
     it('should return participant with fbid=fbid including team, participants, and achievements', async () => {
-      let t1 = await model.db.team.create({name: 't1'})
-      let p1 = await model.db.participant.create({fbid: 'p1', team_id: t1.id})
-      let a1 = await model.db.achievement.create({name: 'a1', distance: 1})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 't1'})
+      let p1 = await models.db.participant.create({fbid: 'p1', team_id: t1.id})
+      let a1 = await models.db.achievement.create({name: 'a1', distance: 1})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/participants/' + p1.fbid)
         .expect(200)
@@ -55,7 +55,7 @@ describe('participants', () => {
     })
     it('should return 409 if participant fbid conflict', async () => {
       let fbid = 'p2'
-      let p2 = await model.db.participant.create({fbid})
+      let p2 = await models.db.participant.create({fbid})
       await koaRequest
         .post('/participants')
         .send({fbid})
@@ -68,8 +68,8 @@ describe('participants', () => {
 
   context('PATCH /participants/:fbid', () => {
     it('should set team for participant with fbid=fbid', async () => {
-      let p1 = await model.db.participant.create({fbid: 'p1'})
-      let t1 = await model.db.team.create({name: 't1'})
+      let p1 = await models.db.participant.create({fbid: 'p1'})
+      let t1 = await models.db.team.create({name: 't1'})
       await koaRequest
         .patch('/participants/' + p1.fbid)
         .send({team_id: t1.id})
@@ -82,7 +82,7 @@ describe('participants', () => {
         .expect(400, [0])
     })
     it('should return 400 if team does not exist', async () => {
-      let p1 = await model.db.participant.create({fbid: 'p1'})
+      let p1 = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .patch('/participants/' + p1.fbid)
         .send({team_id: 1})
@@ -95,7 +95,7 @@ describe('participants', () => {
 
   context('DELETE /participants/:fbid', () => {
     it('should delete participant with fbid=fbid', async () => {
-      let participant = await model.db.participant.create({fbid: 'p1'})
+      let participant = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .del('/participants/' + participant.fbid)
         .expect(204)

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -5,7 +5,7 @@ const chaiAsPromised = require('chai-as-promised')
 const request = require('supertest')
 const http = require('http')
 const server = require('../lib/server.js')
-const model = require('../lib/models')
+const models = require('../lib/models')
 
 chai.should()
 chai.use(chaiAsPromised)
@@ -22,4 +22,4 @@ describe('routes', () => {
   })
 })
 
-module.exports = {koaRequest, model}
+module.exports = {koaRequest, models}

--- a/test/sources-specs.js
+++ b/test/sources-specs.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('sources', () => {
   context('GET /sources', () => {
     it('should return sources', async () => {
-      let s1 = await model.db.source.create({name: 's1'})
-      let s2 = await model.db.source.create({name: 's2'})
+      let s1 = await models.db.source.create({name: 's1'})
+      let s2 = await models.db.source.create({name: 's2'})
       await koaRequest
         .get('/sources')
         .expect(200)
@@ -29,7 +29,7 @@ describe('sources', () => {
         .expect(204)
     })
     it('should return source with id=id', async () => {
-      let s1 = await model.db.source.create({name: 's1'})
+      let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .get('/sources/' + s1.id)
         .expect(200)
@@ -51,7 +51,7 @@ describe('sources', () => {
         })
     })
     it('should return 409 if source name conflict', async () => {
-      let s2 = await model.db.source.create({name: 's2'})
+      let s2 = await models.db.source.create({name: 's2'})
       await koaRequest
         .post('/sources')
         .send({name: s2.name})
@@ -64,7 +64,7 @@ describe('sources', () => {
 
   context('PATCH /sources/:id', () => {
     it('should change source name', async () => {
-      let s1 = await model.db.source.create({name: 's1'})
+      let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .patch('/sources/' + s1.id)
         .send({name: 's2'})
@@ -77,8 +77,8 @@ describe('sources', () => {
         .expect(400, [0])
     })
     it('should return 400 if source name conflict', async () => {
-      let s2 = await model.db.source.create({name: 's2'})
-      let s3 = await model.db.source.create({name: 's3'})
+      let s2 = await models.db.source.create({name: 's2'})
+      let s3 = await models.db.source.create({name: 's3'})
       await koaRequest
         .patch('/sources/' + s2.id)
         .send({name: s3.name})
@@ -91,7 +91,7 @@ describe('sources', () => {
 
   context('DELETE /sources/:id', () => {
     it('should delete source with id=id', async () => {
-      let s1 = await model.db.source.create({name: 's1'})
+      let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .del('/sources/' + s1.id)
         .expect(204)

--- a/test/sponsor-specs.js
+++ b/test/sponsor-specs.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('sponsor', () => {
@@ -18,9 +18,9 @@ describe('sponsor', () => {
         })
     })
     it('should return sponsors', async () => {
-      let sponsor1 = await model.db.sponsor.create({'name': 'Kaiser NC',
+      let sponsor1 = await models.db.sponsor.create({'name': 'Kaiser NC',
         'luminate_id': '001'})
-      let sponsor2 = await model.db.sponsor.create({'name': 'Sutter Health',
+      let sponsor2 = await models.db.sponsor.create({'name': 'Sutter Health',
         'luminate_id': '002'})
       await koaRequest
         .get('/sponsor')
@@ -41,7 +41,7 @@ describe('sponsor', () => {
         .expect(204)
     })
     it('should return sponsor with id=id', async () => {
-      let sponsor = await model.db.sponsor.create({'name': 'Kaiser NC',
+      let sponsor = await models.db.sponsor.create({'name': 'Kaiser NC',
         'luminate_id': '001'})
       await koaRequest
         .get('/sponsor/' + sponsor.id)
@@ -68,7 +68,7 @@ describe('sponsor', () => {
     it('should return 400 if sponsor name conflict', async () => {
       let sponsor1 = {'name': 'Kaiser NC', 'luminate_id': '001'}
       let duplicateNameReq = {'name': 'Kaiser NC', 'luminate_id': '002'}
-      await model.db.sponsor.create(sponsor1)
+      await models.db.sponsor.create(sponsor1)
       await koaRequest
         .post('/sponsor')
         .send(duplicateNameReq)
@@ -77,7 +77,7 @@ describe('sponsor', () => {
     it('should return 400 if sponsor luminate id conflict', async () => {
       let sponsor1 = {'name': 'Cigna', 'luminate_id': '004'}
       let duplicateLuminateReq = {'name': 'Sutter Health', 'luminate_id': '004'}
-      await model.db.sponsor.create(sponsor1)
+      await models.db.sponsor.create(sponsor1)
       await koaRequest
         .post('/sponsor')
         .send(duplicateLuminateReq)
@@ -87,7 +87,7 @@ describe('sponsor', () => {
 
   context('DELETE /sponsor/:id', () => {
     it('should delete sponsor with id=id', async () => {
-      let sponsor = await model.db.sponsor.create({'name': 'Kaiser NC',
+      let sponsor = await models.db.sponsor.create({'name': 'Kaiser NC',
         'luminate_id': '001'})
       await koaRequest
         .del('/sponsor/' + sponsor.id)

--- a/test/teams-specs.js
+++ b/test/teams-specs.js
@@ -1,17 +1,17 @@
 /* eslint-env mocha */
 
 const koaRequest = require('./routes-specs').koaRequest
-const model = require('./routes-specs').model
+const models = require('./routes-specs').models
 
 beforeEach(function syncDB () {
-  return model.db.sequelize.sync({force: true})
+  return models.db.sequelize.sync({force: true})
 })
 
 describe('teams', () => {
   context('GET /teams', () => {
     it('should return teams', async () => {
-      let team1 = await model.db.team.create({name: 'team1'})
-      let team2 = await model.db.team.create({name: 'team2'})
+      let team1 = await models.db.team.create({name: 'team1'})
+      let team2 = await models.db.team.create({name: 'team2'})
       await koaRequest
         .get('/teams')
         .expect(200)
@@ -21,8 +21,8 @@ describe('teams', () => {
         })
     })
     it('should return teams with participants', async () => {
-      let t1 = await model.db.team.create({name: 't1'})
-      let p1 = await model.db.participant.create({fbid: 'p1', team_id: t1.id})
+      let t1 = await models.db.team.create({name: 't1'})
+      let p1 = await models.db.participant.create({fbid: 'p1', team_id: t1.id})
       await koaRequest
         .get('/teams')
         .expect(200)
@@ -32,9 +32,9 @@ describe('teams', () => {
         })
     })
     it('should return teams with achievements', async () => {
-      let t1 = await model.db.team.create({name: 't1'})
-      let a1 = await model.db.achievement.create({name: 'a1', distance: 1})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 't1'})
+      let a1 = await models.db.achievement.create({name: 'a1', distance: 1})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/teams')
         .expect(200)
@@ -53,7 +53,7 @@ describe('teams', () => {
         .expect(204)
     })
     it('should return team with id=id', async () => {
-      let team = await model.db.team.create({name: 'team1'})
+      let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .get('/teams/' + team.id)
         .expect(200)
@@ -62,8 +62,8 @@ describe('teams', () => {
         })
     })
     it('should return team with id=id with participants', async () => {
-      let t1 = await model.db.team.create({name: 't1'})
-      let p1 = await model.db.participant.create({fbid: 'p1', team_id: t1.id})
+      let t1 = await models.db.team.create({name: 't1'})
+      let p1 = await models.db.participant.create({fbid: 'p1', team_id: t1.id})
       await koaRequest
         .get('/teams/' + t1.id)
         .expect(200)
@@ -73,9 +73,9 @@ describe('teams', () => {
         })
     })
     it('should return team with id=id with achievements', async () => {
-      let t1 = await model.db.team.create({name: 't1'})
-      let a1 = await model.db.achievement.create({name: 'a1', distance: 1})
-      await model.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
+      let t1 = await models.db.team.create({name: 't1'})
+      let a1 = await models.db.achievement.create({name: 'a1', distance: 1})
+      await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/teams/' + t1.id)
         .expect(200)
@@ -99,7 +99,7 @@ describe('teams', () => {
         })
     })
     it('should return 409 if team name conflict', async () => {
-      let team2 = await model.db.team.create({name: 'team2'})
+      let team2 = await models.db.team.create({name: 'team2'})
       await koaRequest
         .post('/teams')
         .send({name: team2.name})
@@ -112,7 +112,7 @@ describe('teams', () => {
 
   context('PATCH /teams/:id', () => {
     it('should change team name', async () => {
-      let team = await model.db.team.create({name: 'team1'})
+      let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .patch('/teams/' + team.id)
         .send({name: 'firstTeam'})
@@ -125,8 +125,8 @@ describe('teams', () => {
         .expect(400, [0])
     })
     it('should return 400 if team name conflict', async () => {
-      let team2 = await model.db.team.create({name: 'team2'})
-      let team3 = await model.db.team.create({name: 'team3'})
+      let team2 = await models.db.team.create({name: 'team2'})
+      let team3 = await models.db.team.create({name: 'team3'})
       await koaRequest
         .patch('/teams/' + team2.id)
         .send({name: team3.name})
@@ -139,7 +139,7 @@ describe('teams', () => {
 
   context('DELETE /teams/:id', () => {
     it('should delete team with id=id', async () => {
-      let team = await model.db.team.create({name: 'team1'})
+      let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .del('/teams/' + team.id)
         .expect(204)


### PR DESCRIPTION
* Replace all explicit schema references with ORM associations
* Refactor settings into single `config/config.json` for use with sequelize-cli (will be used for migrations in the next schema update)
* Rename model to models in tests for consistency