### PR TITLE
Add records endpoints

### DIFF
--- a/lib/routes/participants.js
+++ b/lib/routes/participants.js
@@ -18,6 +18,7 @@ router
       },
         models.db.cause,
         models.db.event,
+        models.db.record,
         models.db.source
       ]
     })

--- a/lib/routes/records.js
+++ b/lib/routes/records.js
@@ -1,0 +1,46 @@
+const router = require('koa-router')()
+const models = require('../models')
+
+router
+  .get('/records/:id', async (ctx) => {
+    ctx.body = await models.db.record.findById(
+      ctx.params.id, {
+        include: [models.db.source]
+      })
+  })
+  .post('/records', async (ctx) => {
+    let date = ctx.request.body.date
+    let distance = ctx.request.body.distance
+    let participantId = ctx.request.body.participant_id
+    let sourceId = ctx.request.body.source_id
+    await models.db.record
+      .findOrCreate({where: {
+        date: date,
+        distance: distance,
+        participant_id: participantId,
+        source_id: sourceId
+      }})
+      .spread(function (record, created) {
+        if (created) {
+          ctx.status = 201
+          ctx.body = record
+        } else {
+          ctx.status = 409
+          ctx.body = {'error': {
+            'code': 409,
+            'message': `specified record already exists`
+          }}
+        }
+      })
+  })
+  .del('/records/:id', async (ctx) => {
+    await models.db.record.destroy({
+      where: {id: ctx.params.id}
+    })
+      .then(result => {
+        ctx.status = result ? 204 : 400
+        ctx.body = result
+      })
+  })
+
+module.exports = router

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,7 @@ const sources = require('./routes/sources')
 const causes = require('./routes/causes')
 const events = require('./routes/events')
 const localities = require('./routes/localities')
+const records = require('./routes/records')
 
 const app = new Koa()
 app
@@ -36,5 +37,7 @@ app
   .use(events.allowedMethods())
   .use(localities.routes())
   .use(localities.allowedMethods())
+  .use(records.routes())
+  .use(records.allowedMethods())
 
 module.exports = app

--- a/test/records-specs.js
+++ b/test/records-specs.js
@@ -1,0 +1,106 @@
+/* eslint-env mocha */
+
+const koaRequest = require('./routes-specs').koaRequest
+const models = require('./routes-specs').models
+
+beforeEach(function syncDB () {
+  return models.db.sequelize.sync({force: true})
+})
+
+describe('records', () => {
+  context('GET /records/:id', () => {
+    it('should return 204 if no record with id=id', async () => {
+      await koaRequest
+        .get('/records/1')
+        .expect(204)
+    })
+    it('should return record with id=id', async () => {
+      let p1 = await models.db.participant.create({fbid: 'p1'})
+      let s1 = await models.db.source.create({name: 's1'})
+      let l1 = await models.db.record.create({
+        date: '2017-02-01T00:00:00Z',
+        distance: 1,
+        participant_id: p1.id,
+        source_id: s1.id
+      })
+      await koaRequest
+        .get('/records/' + l1.id)
+        .expect(200)
+        .then(response => {
+          response.body.date.should.be.sameMoment(l1.date)
+          response.body.distance.should.equal(l1.distance)
+          response.body.participant_id.should.equal(l1.participant_id)
+          response.body.source_id.should.equal(l1.source_id)
+        })
+    })
+  })
+
+  context('POST /records', () => {
+    it('should create record with date=date, distance=distance, participant_id=participant_id, source_id=source_id', async () => {
+      let p1 = await models.db.participant.create({fbid: 'p1'})
+      let s1 = await models.db.source.create({name: 's1'})
+      let date = '2017-02-01T00:00:00Z'
+      let distance = 1
+      let participantId = p1.id
+      let sourceId = s1.id
+      await koaRequest
+        .post('/records')
+        .send({
+          date: date,
+          distance: distance,
+          participant_id: participantId,
+          source_id: sourceId
+        })
+        .expect(201)
+        .then(response => {
+          response.body.date.should.be.sameMoment(date)
+          response.body.distance.should.equal(distance)
+          response.body.participant_id.should.equal(participantId)
+          response.body.source_id.should.equal(sourceId)
+        })
+    })
+    it('should return 409 if record conflict', async () => {
+      let p1 = await models.db.participant.create({fbid: 'p1'})
+      let s1 = await models.db.source.create({name: 's1'})
+      let l1 = await models.db.record.create({
+        date: '2017-02-01T00:00:00Z',
+        distance: 1,
+        participant_id: p1.id,
+        source_id: s1.id
+      })
+      await koaRequest
+        .post('/records')
+        .send({
+          date: l1.date,
+          distance: l1.distance,
+          participant_id: l1.participant_id,
+          source_id: l1.source_id
+        })
+        .expect(409, {'error': {
+          'code': 409,
+          'message': `specified record already exists`
+        }})
+    })
+  })
+
+  context('DELETE /records/:id', () => {
+    it('should delete record with id=id', async () => {
+      let p1 = await models.db.participant.create({fbid: 'p1'})
+      let s1 = await models.db.source.create({name: 's1'})
+      let l1 = await models.db.record.create({
+        date: '2017-02-01T00:00:00Z',
+        distance: 1,
+        participant_id: p1.id,
+        source_id: s1.id
+      })
+      await koaRequest
+        .del('/records/' + l1.id)
+        .expect(204)
+    })
+    it('should return 400 if no record with id=id', async () => {
+      await koaRequest
+        .del('/records/' + 0)
+        .expect(400)
+    })
+  })
+})


### PR DESCRIPTION
Resolves #27.

* Note that `GET /records` is unavailable to restrict information disclosure to only clients that created the record and queries through the `/participants` endpoints
* `PATCH /records/:id` is also unavailable because a record should be immutable (delete and recreate if absolutely necessary)