### PR TITLE
Adding simple auth mechanism

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,25 @@
+let accessToken = process.env.ACCESS_TOKEN
+
+async function auth (ctx, next) {
+  // for health check skipping / and retunrning 200
+  if (ctx.request.url === '/') {
+    return await next()
+  }
+
+  // Check if access_token is present in header
+  if (Object.prototype.hasOwnProperty.call(ctx.request.headers, 'access_token') &&
+      ctx.request.headers['access_token'] === accessToken) {
+    return await next()
+  }
+  /*
+  // Check if access_token is present in query
+  if (Object.prototype.hasOwnProperty.call(ctx.request.query, 'access_token') &&
+      ctx.request.query['access_token'] === accessToken) {
+    return await next()
+  }
+  */
+  ctx.body = `Please provide access_token to use WCB service.`
+  ctx.response.status = 401
+}
+
+module.exports = auth

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,10 +13,12 @@ const causes = require('./routes/causes')
 const events = require('./routes/events')
 const localities = require('./routes/localities')
 const records = require('./routes/records')
+const auth = require('./auth')
 
 const app = new Koa()
 app
   .use(bodyParser())
+  .use(auth)
   .use(routes.routes())
   .use(routes.allowedMethods())
   .use(teams.routes())

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "migrate": "sequelize --options-path config/sequelize.json db:migrate",
     "migrate:undo": "sequelize --options-path config/sequelize.json db:migrate:undo",
     "start": "node .",
-    "start-dev": "NODE_ENV=development nodemon .",
-    "test": "NODE_ENV=test istanbul cover --report lcovonly _mocha --recursive"
+    "start-dev": "NODE_ENV=development ACCESS_TOKEN=test nodemon .",
+    "test": "NODE_ENV=test ACCESS_TOKEN=test istanbul cover --report lcovonly _mocha --recursive"
   },
   "repository": {
     "type": "git",

--- a/test/achievement-specs.js
+++ b/test/achievement-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -14,6 +15,7 @@ describe('achievement', () => {
       let a2 = await models.db.achievement.create({name: 'Paris', distance: 200})
       await koaRequest
         .get('/achievement')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(a1.name)
@@ -28,6 +30,7 @@ describe('achievement', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievement')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(a1.name)
@@ -41,12 +44,14 @@ describe('achievement', () => {
     it('should return 204 if no achievement with id=id', async () => {
       await koaRequest
         .get('/achievement/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return achievement with id=id', async () => {
       let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .get('/achievement/' + achievement.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(achievement.name)
@@ -59,6 +64,7 @@ describe('achievement', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievement/' + a1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(a1.name)
@@ -74,6 +80,7 @@ describe('achievement', () => {
       let distance = 100
       await koaRequest
         .post('/achievement')
+        .set('access_token', accessToken)
         .send({name, distance})
         .expect(201)
         .then(response => {
@@ -85,6 +92,7 @@ describe('achievement', () => {
       let a2 = await models.db.achievement.create({name: 'Paris', distance: 100})
       await koaRequest
         .post('/achievement')
+        .set('access_token', accessToken)
         .send({name: a2.name, distance: a2.distance})
         .expect(409, {'error': {
           'code': 409,
@@ -98,12 +106,14 @@ describe('achievement', () => {
       let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .patch('/achievement/' + achievement.id)
+        .set('access_token', accessToken)
         .send({name: 'Paris', distance: 200})
         .expect(200, [1])
     })
     it('should return 400 if no achievement with id=id', async () => {
       await koaRequest
         .patch('/achievement/' + 1)
+        .set('access_token', accessToken)
         .send({name: 'a2'})
         .expect(400, [0])
     })
@@ -112,6 +122,7 @@ describe('achievement', () => {
       let a3 = await models.db.achievement.create({name: 'Amsterdam', distance: 300})
       await koaRequest
         .patch('/achievement/' + a2.id)
+        .set('access_token', accessToken)
         .send({name: a3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -125,11 +136,13 @@ describe('achievement', () => {
       let achievement = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .del('/achievement/' + achievement.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no achievement with id=id', async () => {
       await koaRequest
         .del('/achievement/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/achievements-specs.js
+++ b/test/achievements-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -12,6 +13,7 @@ describe('achievements', () => {
     it('should return empty if no achievements for team with id=team', async () => {
       await koaRequest
         .get('/achievements/team/1')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.should.deep.equal([])
@@ -23,6 +25,7 @@ describe('achievements', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievements/team/' + t1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].team_id.should.equal(t1.id)
@@ -35,6 +38,7 @@ describe('achievements', () => {
     it('should return empty if no achievements for achievement with id=achievement', async () => {
       await koaRequest
         .get('/achievements/achievement/1')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.should.deep.equal([])
@@ -46,6 +50,7 @@ describe('achievements', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/achievements/achievement/' + a1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].team_id.should.equal(t1.id)
@@ -60,6 +65,7 @@ describe('achievements', () => {
       let a1 = await models.db.achievement.create({name: 'London', distance: 100})
       await koaRequest
         .post('/achievements')
+        .set('access_token', accessToken)
         .send({team_id: t1.id, achievement_id: a1.id})
         .expect(201)
         .then(response => {
@@ -73,6 +79,7 @@ describe('achievements', () => {
       let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .post('/achievements')
+        .set('access_token', accessToken)
         .send({team_id: achievements.team_id, achievement_id: achievements.achievement_id})
         .expect(409, {'error': {
           'code': 409,
@@ -90,12 +97,14 @@ describe('achievements', () => {
       let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .patch('/achievements/' + achievements.id)
+        .set('access_token', accessToken)
         .send({team_id: t2.id, achievement_id: a2.id})
         .expect(200, [1])
     })
     it('should return 400 if no achievements with id=id', async () => {
       await koaRequest
         .patch('/achievements/' + 1)
+        .set('access_token', accessToken)
         .send({team_id: 1})
         .expect(400, [0])
     })
@@ -108,6 +117,7 @@ describe('achievements', () => {
       await models.db.achievements.create({team_id: t2.id, achievement_id: a2.id})
       await koaRequest
         .patch('/achievements/' + achievements1.id)
+        .set('access_token', accessToken)
         .send({team_id: t2.id, achievement_id: a2.id})
         .expect(400, {'error': {
           'code': 400,
@@ -123,11 +133,13 @@ describe('achievements', () => {
       let achievements = await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .del('/achievements/' + achievements.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no achievements with id=id', async () => {
       await koaRequest
         .del('/achievements/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/causes-specs.js
+++ b/test/causes-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -14,6 +15,7 @@ describe('causes', () => {
       let c2 = await models.db.cause.create({name: 'c2'})
       await koaRequest
         .get('/causes')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(c1.name)
@@ -26,12 +28,14 @@ describe('causes', () => {
     it('should return 204 if no cause with id=id', async () => {
       await koaRequest
         .get('/causes/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return cause with id=id', async () => {
       let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .get('/causes/' + c1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(c1.name)
@@ -44,6 +48,7 @@ describe('causes', () => {
       let name = 'c1'
       await koaRequest
         .post('/causes')
+        .set('access_token', accessToken)
         .send({name})
         .expect(201)
         .then(response => {
@@ -54,6 +59,7 @@ describe('causes', () => {
       let c2 = await models.db.cause.create({name: 'c2'})
       await koaRequest
         .post('/causes')
+        .set('access_token', accessToken)
         .send({name: c2.name})
         .expect(409, {'error': {
           'code': 409,
@@ -67,12 +73,14 @@ describe('causes', () => {
       let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .patch('/causes/' + c1.id)
+        .set('access_token', accessToken)
         .send({name: 'c2'})
         .expect(200, [1])
     })
     it('should return 400 if no cause with id=id', async () => {
       await koaRequest
         .patch('/causes/' + 1)
+        .set('access_token', accessToken)
         .send({name: 'c2'})
         .expect(400, [0])
     })
@@ -81,6 +89,7 @@ describe('causes', () => {
       let c3 = await models.db.cause.create({name: 'c3'})
       await koaRequest
         .patch('/causes/' + c2.id)
+        .set('access_token', accessToken)
         .send({name: c3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -94,11 +103,13 @@ describe('causes', () => {
       let c1 = await models.db.cause.create({name: 'c1'})
       await koaRequest
         .del('/causes/' + c1.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no cause with id=id', async () => {
       await koaRequest
         .del('/causes/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/events-specs.js
+++ b/test/events-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -30,6 +31,7 @@ describe('events', () => {
       })
       await koaRequest
         .get('/events')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(e1.name)
@@ -54,6 +56,7 @@ describe('events', () => {
     it('should return 204 if no event with id=id', async () => {
       await koaRequest
         .get('/events/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return event with id=id', async () => {
@@ -68,6 +71,7 @@ describe('events', () => {
       })
       await koaRequest
         .get('/events/' + e1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(e1.name)
@@ -101,6 +105,7 @@ describe('events', () => {
           team_building_start: teamBuildingStart,
           team_building_end: teamBuildingEnd
         })
+        .set('access_token', accessToken)
         .expect(201)
         .then(response => {
           response.body.name.should.equal(name)
@@ -140,6 +145,7 @@ describe('events', () => {
           team_building_start: '2018-01-01T00:00:00Z',
           team_building_end: '2018-01-31T00:00:00Z'
         })
+        .set('access_token', accessToken)
         .expect(409, {'error': {
           'code': 409,
           'message': `event named "${e1.name}" already exists`
@@ -160,6 +166,7 @@ describe('events', () => {
       })
       await koaRequest
         .patch('/events/' + e1.id)
+        .set('access_token', accessToken)
         .send({
           name: 'e2',
           description: 'event 2',
@@ -174,6 +181,7 @@ describe('events', () => {
     it('should return 400 if no event with id=id', async () => {
       await koaRequest
         .patch('/events/' + 1)
+        .set('access_token', accessToken)
         .send({name: 'e2'})
         .expect(400, [0])
     })
@@ -198,6 +206,7 @@ describe('events', () => {
       })
       await koaRequest
         .patch('/events/' + e2.id)
+        .set('access_token', accessToken)
         .send({name: e3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -219,11 +228,13 @@ describe('events', () => {
       })
       await koaRequest
         .del('/events/' + e1.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no event with id=id', async () => {
       await koaRequest
         .del('/events/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/localities-specs.js
+++ b/test/localities-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -14,6 +15,7 @@ describe('localities', () => {
       let l2 = await models.db.locality.create({name: 'l2'})
       await koaRequest
         .get('/localities')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(l1.name)
@@ -26,12 +28,14 @@ describe('localities', () => {
     it('should return 204 if no locality with id=id', async () => {
       await koaRequest
         .get('/localities/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return locality with id=id', async () => {
       let l1 = await models.db.locality.create({name: 'l1'})
       await koaRequest
         .get('/localities/' + l1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(l1.name)
@@ -44,6 +48,7 @@ describe('localities', () => {
       let name = 'l1'
       await koaRequest
         .post('/localities')
+        .set('access_token', accessToken)
         .send({name})
         .expect(201)
         .then(response => {
@@ -54,6 +59,7 @@ describe('localities', () => {
       let l2 = await models.db.locality.create({name: 'l2'})
       await koaRequest
         .post('/localities')
+        .set('access_token', accessToken)
         .send({name: l2.name})
         .expect(409, {'error': {
           'code': 409,
@@ -67,12 +73,14 @@ describe('localities', () => {
       let l1 = await models.db.locality.create({name: 'l1'})
       await koaRequest
         .patch('/localities/' + l1.id)
+        .set('access_token', accessToken)
         .send({name: 'l2'})
         .expect(200, [1])
     })
     it('should return 400 if no locality with id=id', async () => {
       await koaRequest
         .patch('/localities/' + 1)
+        .set('access_token', accessToken)
         .send({name: 'l2'})
         .expect(400, [0])
     })
@@ -81,6 +89,7 @@ describe('localities', () => {
       let l3 = await models.db.locality.create({name: 'l3'})
       await koaRequest
         .patch('/localities/' + l2.id)
+        .set('access_token', accessToken)
         .send({name: l3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -94,11 +103,13 @@ describe('localities', () => {
       let l1 = await models.db.locality.create({name: 'l1'})
       await koaRequest
         .del('/localities/' + l1.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no locality with id=id', async () => {
       await koaRequest
         .del('/localities/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/participants-specs.js
+++ b/test/participants-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -12,12 +13,14 @@ describe('participants', () => {
     it('should return 204 if no participant with fbid=fbid', async () => {
       await koaRequest
         .get('/participants/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return participant with fbid=fbid', async () => {
       let participant = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .get('/participants/' + participant.fbid)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.fbid.should.equal(participant.fbid)
@@ -30,6 +33,7 @@ describe('participants', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/participants/' + p1.fbid)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.fbid.should.equal(p1.fbid)
@@ -46,6 +50,7 @@ describe('participants', () => {
     it('should return 204 if no participant with fbid=fbid', async () => {
       await koaRequest
         .get('/participants/1/stats')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return sum of distances for participant with fbid=fbid', async () => {
@@ -65,6 +70,7 @@ describe('participants', () => {
       })
       await koaRequest
         .get('/participants/' + p1.fbid + '/stats')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.distance.should.equal(r1.distance + r2.distance)
@@ -77,6 +83,7 @@ describe('participants', () => {
       let fbid = 'p1'
       await koaRequest
         .post('/participants')
+        .set('access_token', accessToken)
         .send({fbid})
         .expect(201)
         .then(response => {
@@ -88,6 +95,7 @@ describe('participants', () => {
       let p2 = await models.db.participant.create({fbid})
       await koaRequest
         .post('/participants')
+        .set('access_token', accessToken)
         .send({fbid})
         .expect(409, {'error': {
           'code': 409,
@@ -102,12 +110,14 @@ describe('participants', () => {
       let t1 = await models.db.team.create({name: 't1'})
       await koaRequest
         .patch('/participants/' + p1.fbid)
+        .set('access_token', accessToken)
         .send({team_id: t1.id})
         .expect(200)
     })
     it('should return 400 if no participant with id=id', async () => {
       await koaRequest
         .patch('/participants/' + 1)
+        .set('access_token', accessToken)
         .send({team_id: 1})
         .expect(400, [0])
     })
@@ -115,6 +125,7 @@ describe('participants', () => {
       let p1 = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .patch('/participants/' + p1.fbid)
+        .set('access_token', accessToken)
         .send({team_id: 1})
         .expect(400, {'error': {
           'code': 400,
@@ -128,11 +139,13 @@ describe('participants', () => {
       let participant = await models.db.participant.create({fbid: 'p1'})
       await koaRequest
         .del('/participants/' + participant.fbid)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no participant with fbid=fbid', async () => {
       await koaRequest
         .del('/participants/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/records-specs.js
+++ b/test/records-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -12,6 +13,7 @@ describe('records', () => {
     it('should return 204 if no record with id=id', async () => {
       await koaRequest
         .get('/records/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return record with id=id', async () => {
@@ -25,6 +27,7 @@ describe('records', () => {
       })
       await koaRequest
         .get('/records/' + l1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.date.should.be.sameMoment(l1.date)
@@ -45,6 +48,7 @@ describe('records', () => {
       let sourceId = s1.id
       await koaRequest
         .post('/records')
+        .set('access_token', accessToken)
         .send({
           date: date,
           distance: distance,
@@ -70,6 +74,7 @@ describe('records', () => {
       })
       await koaRequest
         .post('/records')
+        .set('access_token', accessToken)
         .send({
           date: l1.date,
           distance: l1.distance,
@@ -95,11 +100,13 @@ describe('records', () => {
       })
       await koaRequest
         .del('/records/' + l1.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no record with id=id', async () => {
       await koaRequest
         .del('/records/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/routes-specs.js
+++ b/test/routes-specs.js
@@ -5,6 +5,7 @@ const request = require('supertest')
 const http = require('http')
 const server = require('../lib/server.js')
 const models = require('../lib/models')
+let accessToken = process.env.ACCESS_TOKEN
 
 chai.should()
 chai.use(require('chai-as-promised'))
@@ -17,6 +18,7 @@ describe('routes', () => {
     it('should respond 200', async () => {
       await koaRequest
         .get('/')
+        .set('access_token', accessToken)
         .expect(200, {'status': 'OK'})
     })
   })

--- a/test/sources-specs.js
+++ b/test/sources-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -14,6 +15,7 @@ describe('sources', () => {
       let s2 = await models.db.source.create({name: 's2'})
       await koaRequest
         .get('/sources')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(s1.name)
@@ -26,12 +28,14 @@ describe('sources', () => {
     it('should return 204 if no source with id=id', async () => {
       await koaRequest
         .get('/sources/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return source with id=id', async () => {
       let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .get('/sources/' + s1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(s1.name)
@@ -44,6 +48,7 @@ describe('sources', () => {
       let name = 's1'
       await koaRequest
         .post('/sources')
+        .set('access_token', accessToken)
         .send({name})
         .expect(201)
         .then(response => {
@@ -54,6 +59,7 @@ describe('sources', () => {
       let s2 = await models.db.source.create({name: 's2'})
       await koaRequest
         .post('/sources')
+        .set('access_token', accessToken)
         .send({name: s2.name})
         .expect(409, {'error': {
           'code': 409,
@@ -67,12 +73,14 @@ describe('sources', () => {
       let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .patch('/sources/' + s1.id)
+        .set('access_token', accessToken)
         .send({name: 's2'})
         .expect(200, [1])
     })
     it('should return 400 if no source with id=id', async () => {
       await koaRequest
         .patch('/sources/' + 1)
+        .set('access_token', accessToken)
         .send({name: 's2'})
         .expect(400, [0])
     })
@@ -81,6 +89,7 @@ describe('sources', () => {
       let s3 = await models.db.source.create({name: 's3'})
       await koaRequest
         .patch('/sources/' + s2.id)
+        .set('access_token', accessToken)
         .send({name: s3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -94,11 +103,13 @@ describe('sources', () => {
       let s1 = await models.db.source.create({name: 's1'})
       await koaRequest
         .del('/sources/' + s1.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no source with id=id', async () => {
       await koaRequest
         .del('/sources/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })

--- a/test/sponsor-specs.js
+++ b/test/sponsor-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -12,6 +13,7 @@ describe('sponsor', () => {
     it('should return empty array if no sponsors', async () => {
       await koaRequest
         .get('/sponsor')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.length.should.equal(0)
@@ -24,6 +26,7 @@ describe('sponsor', () => {
         'luminate_id': '002'})
       await koaRequest
         .get('/sponsor')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(sponsor1.name)
@@ -38,6 +41,7 @@ describe('sponsor', () => {
     it('should return 204 if no sponsor with id=id', async () => {
       await koaRequest
         .get('/sponsor/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return sponsor with id=id', async () => {
@@ -45,6 +49,7 @@ describe('sponsor', () => {
         'luminate_id': '001'})
       await koaRequest
         .get('/sponsor/' + sponsor.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(sponsor.name)
@@ -58,6 +63,7 @@ describe('sponsor', () => {
       let body = {'name': 'Blue Shield', 'luminate_id': '003'}
       await koaRequest
         .post('/sponsor')
+        .set('access_token', accessToken)
         .send(body)
         .expect(201)
         .then(response => {
@@ -71,6 +77,7 @@ describe('sponsor', () => {
       await models.db.sponsor.create(sponsor1)
       await koaRequest
         .post('/sponsor')
+        .set('access_token', accessToken)
         .send(duplicateNameReq)
         .expect(400)
     })
@@ -80,6 +87,7 @@ describe('sponsor', () => {
       await models.db.sponsor.create(sponsor1)
       await koaRequest
         .post('/sponsor')
+        .set('access_token', accessToken)
         .send(duplicateLuminateReq)
         .expect(400)
     })
@@ -91,11 +99,13 @@ describe('sponsor', () => {
         'luminate_id': '001'})
       await koaRequest
         .del('/sponsor/' + sponsor.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no sponsor with id=id', async () => {
       await koaRequest
         .del('/sponsor/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
         .then(response => {
           response.body.should.equal(0)

--- a/test/teams-specs.js
+++ b/test/teams-specs.js
@@ -2,6 +2,7 @@
 
 const koaRequest = require('./routes-specs').koaRequest
 const models = require('./routes-specs').models
+let accessToken = process.env.ACCESS_TOKEN
 
 beforeEach(function syncDB () {
   return models.db.sequelize.sync({force: true})
@@ -14,6 +15,7 @@ describe('teams', () => {
       let team2 = await models.db.team.create({name: 'team2'})
       await koaRequest
         .get('/teams')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(team1.name)
@@ -25,6 +27,7 @@ describe('teams', () => {
       let p1 = await models.db.participant.create({fbid: 'p1', team_id: t1.id})
       await koaRequest
         .get('/teams')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(t1.name)
@@ -37,6 +40,7 @@ describe('teams', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/teams')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body[0].name.should.equal(t1.name)
@@ -50,12 +54,14 @@ describe('teams', () => {
     it('should return 204 if no team with id=id', async () => {
       await koaRequest
         .get('/teams/1')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return team with id=id', async () => {
       let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .get('/teams/' + team.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(team.name)
@@ -66,6 +72,7 @@ describe('teams', () => {
       let p1 = await models.db.participant.create({fbid: 'p1', team_id: t1.id})
       await koaRequest
         .get('/teams/' + t1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(t1.name)
@@ -78,6 +85,7 @@ describe('teams', () => {
       await models.db.achievements.create({team_id: t1.id, achievement_id: a1.id})
       await koaRequest
         .get('/teams/' + t1.id)
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.name.should.equal(t1.name)
@@ -91,6 +99,7 @@ describe('teams', () => {
     it('should return 204 if no team with id=id', async () => {
       await koaRequest
         .get('/teams/1/stats')
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return sum of distances for participants in team with id=id', async () => {
@@ -112,6 +121,7 @@ describe('teams', () => {
       })
       await koaRequest
         .get('/teams/' + t1.id + '/stats')
+        .set('access_token', accessToken)
         .expect(200)
         .then(response => {
           response.body.distance.should.equal(r1.distance + r2.distance)
@@ -124,6 +134,7 @@ describe('teams', () => {
       let name = 'team1'
       await koaRequest
         .post('/teams')
+        .set('access_token', accessToken)
         .send({name})
         .expect(201)
         .then(response => {
@@ -134,6 +145,7 @@ describe('teams', () => {
       let team2 = await models.db.team.create({name: 'team2'})
       await koaRequest
         .post('/teams')
+        .set('access_token', accessToken)
         .send({name: team2.name})
         .expect(409, {'error': {
           'code': 409,
@@ -147,12 +159,14 @@ describe('teams', () => {
       let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .patch('/teams/' + team.id)
+        .set('access_token', accessToken)
         .send({name: 'firstTeam'})
         .expect(200, [1])
     })
     it('should return 400 if no team with id=id', async () => {
       await koaRequest
         .patch('/teams/' + 1)
+        .set('access_token', accessToken)
         .send({name: 't2'})
         .expect(400, [0])
     })
@@ -161,6 +175,7 @@ describe('teams', () => {
       let team3 = await models.db.team.create({name: 'team3'})
       await koaRequest
         .patch('/teams/' + team2.id)
+        .set('access_token', accessToken)
         .send({name: team3.name})
         .expect(400, {'error': {
           'code': 400,
@@ -174,11 +189,13 @@ describe('teams', () => {
       let team = await models.db.team.create({name: 'team1'})
       await koaRequest
         .del('/teams/' + team.id)
+        .set('access_token', accessToken)
         .expect(204)
     })
     it('should return 400 if no team with id=id', async () => {
       await koaRequest
         .del('/teams/' + 0)
+        .set('access_token', accessToken)
         .expect(400)
     })
   })


### PR DESCRIPTION
@alykhank @javedlalani @compnerd Please review. Adding auth mechanism to provide access_token as part of header of the request.

For example
```
curl -H "access_token: ACCESS_TOKEN" <req>
```