### PR TITLE
Adding CI pipeline for build, push and release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2
+jobs:
+  lint:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          name: Running Lints...
+          command: make lint
+
+  test:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          name: Running Tests...
+          command: make test
+  
+  build:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Building Docker Image...
+          command: make build
+  
+  release:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout 
+      - setup_remote_docker
+      - run:
+          name: Configuring Git credentials...
+          command: |
+            git config user.email "moiz.nidhi+ci@gmail.com"
+            git config user.name "ci-build"
+      - add_ssh_keys:
+          fingerprints:
+            - "7d:c8:37:dc:e9:4c:cd:f5:7c:2d:a4:e7:3f:5f:e2:d4"
+      - run:
+          name: Release to Quay and Git master
+          command: make release 
+      
+
+
+
+workflows:
+  version: 2
+  build_release:
+    jobs:
+      - lint
+      - test
+      - build
+      - release:
+          requires:
+            - test
+            - lint
+            - build
+          filters:
+            branches:
+              only: master
+
+
+

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ REPO_NAME="agakhanfoundation"
 
 install:
 	@npm install
+	echo "SERVER_PASSWORD=<password>" >> .env
 
 test: install
 	@npm test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# Usage: 
+# Install npm packages using package.json
+VERSION:=$(shell npm version| grep wcb | awk '{print $$3}' | sed "s/[\',]//g")
+APP_NAME="wcb"
+REPO_NAME="agakhanfoundation"
+
+
+install:
+	@npm install
+
+test: install
+	@npm test
+
+lint: install
+	@npm run lint
+
+develop: install test lint
+	@npm run start-dev
+
+build:
+	@echo $(APP_NAME):$(VERSION)
+	@docker build . --tag $(APP_NAME):$(VERSION)
+	
+release: 
+	@npm version --no-git-tag-version minor
+	@git add package*.json
+	@docker login -u="${QUAY_USERNAME}" -p="${QUAY_TOKEN}" quay.io
+	@docker build . --tag quay.io/$(REPO_NAME)/$(APP_NAME):$(VERSION)-testing
+	@docker push quay.io/$(REPO_NAME)/$(APP_NAME):$(VERSION)-testing
+	@git commit -m "$(VERSION) [ci skip]"
+	@git push origin master
+	

--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@ Work in progress!
 ## Development
 
 ```
-echo "SERVER_PASSWORD=<password>" >> .env
-npm install
-npm run lint
-npm test
-npm run start-dev
+make develop
 ```
 
 ### Database Migrations
@@ -37,7 +33,7 @@ npm run migrate:undo
 To build the docker container locally
 
 ```
-docker build -t <name> .
+make build
 ```
 
 To run docker container locally


### PR DESCRIPTION
- Added Makefile to implement local development easy by running `make develop`
- Added CI pipeline to test, lint, build and release.
- Release will bump the semantic version and also push same version for docker to quay.
- Sample release: https://circleci.com/workflow-run/83422c9f-b9d7-40c3-b20c-3e30b88e938d